### PR TITLE
feat: rebrand for mtumba and show condition

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
       rel="stylesheet"
     >
-    <title>ShopLite — Modern E-Commerce</title>
+    <title>MtumbaHub — Advanced Mtumba E-Commerce</title>
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -10,7 +10,7 @@ export default function Navbar() {
       <nav className="container flex h-16 items-center justify-between">
         <Link to="/" className="font-extrabold text-xl">
           <span className="bg-gradient-to-r from-blue-600 to-gray-600 bg-clip-text text-transparent">
-            ShopLite
+            MtumbaHub
           </span>
         </Link>
 

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -20,6 +20,9 @@ export default function ProductCard({ product }) {
       <div className="p-4 flex-1 flex flex-col">
         <h3 className="font-semibold text-gray-900">{product.name}</h3>
         <p className="text-sm text-gray-500 line-clamp-2 mt-1">{product.description}</p>
+        {product.condition && (
+          <p className="text-xs text-gray-500 mt-1">Condition: {product.condition}</p>
+        )}
         <div className="mt-auto pt-4 flex items-center justify-between">
           <span className="font-bold text-gray-900">{formatCurrency(product.price)}</span>
           <button

--- a/src/data/products.json
+++ b/src/data/products.json
@@ -1,66 +1,74 @@
 [
   {
     "id": 1,
-    "name": "Wireless Headphones",
-    "price": 79.99,
-    "description": "Comfortable over-ear wireless headphones with 30-hour battery life.",
-    "image": "https://placehold.co/600x400/0ea5e9/ffffff?text=Wireless+Headphones",
-    "category": "Electronics"
+    "name": "Vintage Denim Jacket",
+    "price": 25.0,
+    "description": "Grade A denim jacket with minimal wear.",
+    "image": "https://placehold.co/600x400/0ea5e9/ffffff?text=Denim+Jacket",
+    "category": "Outerwear",
+    "condition": "Grade A"
   },
   {
     "id": 2,
-    "name": "Smartwatch Pro",
-    "price": 129.99,
-    "description": "Track fitness, notifications, and sleep with a crisp AMOLED display.",
-    "image": "https://placehold.co/600x400/22c55e/ffffff?text=Smartwatch+Pro",
-    "category": "Electronics"
+    "name": "Designer Handbag",
+    "price": 40.0,
+    "description": "Pre-loved designer handbag in excellent condition.",
+    "image": "https://placehold.co/600x400/22c55e/ffffff?text=Handbag",
+    "category": "Accessories",
+    "condition": "Grade A"
   },
   {
     "id": 3,
-    "name": "Organic Cotton Tee",
-    "price": 19.99,
-    "description": "Soft, breathable t-shirt made from 100% organic cotton.",
-    "image": "https://placehold.co/600x400/6366f1/ffffff?text=Cotton+Tee",
-    "category": "Clothing"
+    "name": "Men's Formal Shirt",
+    "price": 10.0,
+    "description": "Lightly used cotton shirt perfect for office wear.",
+    "image": "https://placehold.co/600x400/6366f1/ffffff?text=Formal+Shirt",
+    "category": "Men",
+    "condition": "Grade B"
   },
   {
     "id": 4,
-    "name": "Insulated Water Bottle",
-    "price": 24.99,
-    "description": "Keeps drinks cold for 24 hours or hot for 12 hours.",
-    "image": "https://placehold.co/600x400/f59e0b/ffffff?text=Water+Bottle",
-    "category": "Home Goods"
+    "name": "Kids' Cartoon Tee",
+    "price": 5.0,
+    "description": "Secondhand tee with vibrant print.",
+    "image": "https://placehold.co/600x400/f59e0b/ffffff?text=Kids+Tee",
+    "category": "Kids",
+    "condition": "Grade B"
   },
   {
     "id": 5,
-    "name": "Minimalist Backpack",
-    "price": 54.99,
-    "description": "Sleek, durable backpack with padded laptop sleeve.",
-    "image": "https://placehold.co/600x400/0ea5e9/ffffff?text=Backpack",
-    "category": "Clothing"
+    "name": "Women's Sneakers",
+    "price": 18.0,
+    "description": "Comfortable sneakers with minor wear.",
+    "image": "https://placehold.co/600x400/0ea5e9/ffffff?text=Sneakers",
+    "category": "Women",
+    "condition": "Grade A"
   },
   {
     "id": 6,
-    "name": "Bluetooth Speaker",
-    "price": 39.99,
-    "description": "Portable speaker with rich bass and splash resistance.",
-    "image": "https://placehold.co/600x400/ef4444/ffffff?text=Speaker",
-    "category": "Electronics"
+    "name": "Assorted Bale - 50pcs",
+    "price": 200.0,
+    "description": "Mixed-grade clothing bale for resellers.",
+    "image": "https://placehold.co/600x400/ef4444/ffffff?text=Clothing+Bale",
+    "category": "Bales",
+    "condition": "Mixed"
   },
   {
     "id": 7,
-    "name": "Ceramic Mug Set",
-    "price": 29.99,
-    "description": "Set of 4 matte ceramic mugs, dishwasher safe.",
-    "image": "https://placehold.co/600x400/14b8a6/ffffff?text=Mug+Set",
-    "category": "Home Goods"
+    "name": "Winter Coat",
+    "price": 30.0,
+    "description": "Heavy winter coat, gently used.",
+    "image": "https://placehold.co/600x400/14b8a6/ffffff?text=Winter+Coat",
+    "category": "Outerwear",
+    "condition": "Grade A"
   },
   {
     "id": 8,
-    "name": "Running Shoes",
-    "price": 89.99,
-    "description": "Lightweight, breathable shoes for everyday training.",
-    "image": "https://placehold.co/600x400/3b82f6/ffffff?text=Running+Shoes",
-    "category": "Clothing"
+    "name": "Classic Leather Belt",
+    "price": 8.0,
+    "description": "Pre-owned genuine leather belt.",
+    "image": "https://placehold.co/600x400/3b82f6/ffffff?text=Leather+Belt",
+    "category": "Accessories",
+    "condition": "Grade B"
   }
 ]

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -13,11 +13,10 @@ export default function HomePage() {
           <div className="p-8 md:p-14 grid md:grid-cols-2 gap-8 items-center">
             <div>
               <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight text-gray-900">
-                Find Your Next Favorite Thing
+                Premium Mtumba Marketplace
               </h1>
               <p className="mt-4 text-gray-600">
-                Clean, modern shopping experience built with React + Tailwind.
-                Fully responsive and fast.
+                Discover high-quality secondhand fashion with an advanced React + Tailwind experience.
               </p>
               <div className="mt-6 flex gap-3">
                 <Link to="/products" className="btn btn-primary">Shop Now</Link>
@@ -26,12 +25,12 @@ export default function HomePage() {
             </div>
             <div className="relative">
               <img
-                src="https://placehold.co/600x400/111827/ffffff?text=ShopLite+Hero"
+                src="https://placehold.co/600x400/111827/ffffff?text=MtumbaHub+Hero"
                 alt="Hero"
                 className="rounded-xl shadow-lg w-full"
               />
               <div className="absolute -bottom-4 -right-4 bg-white shadow-lg rounded-xl px-4 py-2 text-sm">
-                Modern • Minimal • Fast
+                Sustainable • Affordable • Stylish
               </div>
             </div>
           </div>

--- a/src/pages/ProductDetailPage.jsx
+++ b/src/pages/ProductDetailPage.jsx
@@ -32,6 +32,9 @@ export default function ProductDetailPage() {
         <div className="card p-6">
           <h1 className="text-2xl md:text-3xl font-bold">{product.name}</h1>
           <p className="text-gray-500 mt-2">{product.category}</p>
+          {product.condition && (
+            <p className="text-gray-500 text-sm mt-1">Condition: {product.condition}</p>
+          )}
           <div className="mt-4 text-2xl font-extrabold">{formatCurrency(product.price)}</div>
           <p className="mt-4 text-gray-700">{product.description}</p>
 


### PR DESCRIPTION
## Summary
- rebrand interface to MtumbaHub and highlight sustainable mtumba fashion
- add condition metadata to mtumba products and display it on cards and detail views
- populate product list with mtumba-specific sample items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68962b0c0c108329bc97955436420473